### PR TITLE
Epic Issue type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ The tool for migration from YouTrack to Jira: easy and for free
   1. [Needed Perl modules](#perl-modules)
 
 ## Capabilities
+Supported Versions (tested with):
+* YouTrack - 2022.2 / API latest
+* Jira - 8.16.0 / API 2.0 (latest)
+
 Lumper can:
 
   * Copy all issues
@@ -90,7 +94,7 @@ Lean back in you chair and prepare for a very long process.
 `Description` - the body of the ticket cannot contain more than 32 767 symbols and it will be trimmed as well. However, long descriptions will be saved as `description.md` attachment.
 
 ### Note On Some Specific Issue Types
-`Epic` - this type of an issue requires special field `Epic Name` which is not supported by Lumper. You have to remove this field in order to do mapping to `Epic` type if that is possible, some instructions can be found here, but it requires you some research (here's the [link](https://confluence.atlassian.com/jirakb/epic-name-field-is-required-on-create-issue-screen-for-other-issue-types-779158642.html))
+`Epic` - this type of an issue requires special field `Epic Name`, this field is mandatory, so Lumper will fill it with `Summary` text.
 
 ### Attachments
 Attachments will be renamed to `attachment<number>` to avoid problems with exotic filenames. However, attachment links will be exported correctly.
@@ -99,6 +103,7 @@ Attachments will be saved on your hard disk during export process (in the tempor
 
 
 ## Needed Perl modules
+Make sure all of them present in your perl environment.  
 To install these components you'll need `cpan` utility. 
 
 In cmd/bash type 
@@ -123,3 +128,6 @@ Here's the list of used components:
   * Encode
   * Date::Format
   * File::Temp
+  * File::Basename
+  * List::Util
+  * HTTP::Cookies::Netscape

--- a/migrate.pl
+++ b/migrate.pl
@@ -174,6 +174,11 @@ foreach my $issue (sort { $a->{numberInProject} <=> $b->{numberInProject} } @{$e
 			$custom{$CustomFields{$field}} = $issue->{$field};
 		}
 	}
+
+	# Epic Name special field is required for Jira Epic issues type
+	if ($import{issuetype}->{name} == 'Epic') {
+		$custom{"Epic Name"} = $issue->{summary};
+	}
 	
 	# Add YouTrack original creation date field	
 	my %dateTimeFormats = (


### PR DESCRIPTION
# Summary
Lumper update 2.1 - Epic type of an issue support. There was no possibility to export Epic issues due to special mandatory field called `Epic Name`. Lumper will fill it based on `Summary` (aka Issue Title) field.  

Tested on another big YouTrack project during migration process.

# What's New
* Lumper can now export Epic type of an issue
* ReadMe updated